### PR TITLE
Feature/add-trimming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Release Build
+
 on:
   release:
     types: [published, edited]
@@ -35,7 +37,7 @@ jobs:
 
       - name: Archive and Hash
         run: |
-          zip -r ./out/${{ matrix.target }}.zip ./out/${{ matrix.target }} -j
+          zip -9 -j -r ./out/${{ matrix.target }}.zip ./out/${{ matrix.target }}
           sha256sum ./out/${{ matrix.target }}.zip > ./out/${{ matrix.target }}.zip.sha256
 
       - name: Upload

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,39 @@
+name: Test Build Configuration
+
+on:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: Comma separated list of string targets to build
+        default: '"linux-x64","linux-musl-x64","linux-arm","linux-arm64","osx-x64","osx-arm64","win-arm64","win-x64","win-x86"'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: ${{ fromJson(format('[{0}]', inputs.targets || '"linux-x64","linux-musl-x64","linux-arm","linux-arm64","osx-x64","osx-arm64","win-arm64","win-x64","win-x86"')) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3
+        with:
+          dotnet-version: "8.0"
+
+      - name: Build
+        run: dotnet publish -c Release --self-contained -p:DebugType=None -p:DebugSymbols=false -p:PublishReadyToRun=true -p:Version=0.0.0-test -r ${{ matrix.target }} -o out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
+
+      - name: Archive and Hash
+        run: |
+          zip -9 -r ./out/${{ matrix.target }}.zip ./out/${{ matrix.target }} -j
+          sha256sum ./out/${{ matrix.target }}.zip > ./out/${{ matrix.target }}.zip.sha256
+
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: ./out/*

--- a/src/yk-csr-cli/GenerateYKCSR.csproj
+++ b/src/yk-csr-cli/GenerateYKCSR.csproj
@@ -16,7 +16,7 @@
     <UseAppHost>true</UseAppHost>
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-    <PublishTrimmed>false</PublishTrimmed>
+    <PublishTrimmed>true</PublishTrimmed>
     <AssemblyName>yk-csr-gen</AssemblyName>
   </PropertyGroup>
 


### PR DESCRIPTION
This commit adds a workflow file that sets up a test build configuration for different targets. The workflow is triggered on push events to the "feature/add-trimming" branch and pull requests to the "main" branch where the workflow file itself is modified. The targets are specified as inputs, with a default value of a comma-separated list of target platforms. The build job runs on Ubuntu latest and uses a matrix strategy to build for each target platform specified. Steps include checking out the code, setting up .NET 8.0, building the project with specific publish, debug, and version options, archiving the build artifacts, and uploading them as artifacts for later use.

Signed-off-by: Bryan Gonzalez <bryan@battleface.com>