### PR TITLE
Simplify dotnet publish and update project config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           dotnet-version: "8.0"
 
       - name: Build
-        run: dotnet publish -c Release --self-contained -p:DebugType=None -p:DebugSymbols=false -p:PublishReadyToRun=true -p:Version=$(echo ${{ github.event.release.tag_name }} | cut -c2-) -r ${{ matrix.target }} -o out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
+        run: dotnet publish -p:PublishProfile=Default -p:Version=$(echo ${{ github.event.release.tag_name }} | cut -c2-) -r ${{ matrix.target }} -o out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
 
       - name: Archive and Hash
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -188,7 +188,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+# *.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/src/yk-csr-cli/GenerateYKCSR.csproj
+++ b/src/yk-csr-cli/GenerateYKCSR.csproj
@@ -8,25 +8,19 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <AssemblyName>yk-csr-gen</AssemblyName>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <LangVersion>preview</LangVersion>
+    <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
-    <UseAppHost>true</UseAppHost>
-    <PublishSingleFile>true</PublishSingleFile>
-    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
-    <PublishTrimmed>true</PublishTrimmed>
-    <AssemblyName>yk-csr-gen</AssemblyName>
+    <UseRidGraph>true</UseRidGraph> <!-- Remove when Yubico changes ubuntu- to linux- rid's -->
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Yubico.YubiKey" Version="1.9.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
   </ItemGroup>
 
 </Project>

--- a/src/yk-csr-cli/Properties/PublishProfiles/Aot.pubxml
+++ b/src/yk-csr-cli/Properties/PublishProfiles/Aot.pubxml
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="Common.props" />
+
+  <PropertyGroup>
+    <PublishAot>true</PublishAot>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+</Project>

--- a/src/yk-csr-cli/Properties/PublishProfiles/Common.props
+++ b/src/yk-csr-cli/Properties/PublishProfiles/Common.props
@@ -1,0 +1,9 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <OutputType>Exe</OutputType>
+    <!-- <SelfContained>true</SelfContained> -->
+    <PublishTrimmed>true</PublishTrimmed>
+  </PropertyGroup>
+</Project>

--- a/src/yk-csr-cli/Properties/PublishProfiles/Default.pubxml
+++ b/src/yk-csr-cli/Properties/PublishProfiles/Default.pubxml
@@ -1,0 +1,13 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="Common.props" />
+
+  <PropertyGroup>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishSingleFile>true</PublishSingleFile>
+    <RuntimeIdentifiers>linux-x64;linux-musl-x64;linux-arm;linux-arm64;osx-x64;osx-arm64;win-arm64;win-x64;win-x86</RuntimeIdentifiers>
+    <UseAppHost>true</UseAppHost>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Refactored the GitHub Actions workflow to use a more streamlined dotnet publish command by referencing predefined publish profiles. This change introduces Default and Aot publishing profiles that centralize common publishing settings and provide a foundation for future publishing scenario diversifications. By leveraging publish profiles, we ensure consistency across our build and release pipelines, while also making the process more maintainable.

In the csproj file, we've refined the project configuration by organizing property groups and incorporating `UseRidGraph`, preparing for potential platform identifier transitions by external dependencies like Yubico. The `.gitignore` modification clarifies our stance on keeping `.pubxml` files version-controlled unless they contain sensitive information.

The addition of `Common.props`, `Aot.pubxml`, and `Default.pubxml` under the PublishProfiles directory encapsulates shared properties and specific configurations for Ahead-of-Time compilation and default publishing scenarios, respectively. This setup paves the way for more targeted build optimizations and aligns with best practices for .NET application deployment.

These changes collectively aim to enhance the build efficiency, clarity in project settings, and adaptability to future .NET platform evolutions.