### PR TITLE
Uniform dotnet publish command syntax across workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           dotnet-version: "8.0"
 
       - name: Build
-        run: dotnet publish -p:PublishProfile=Default -p:Version=$(echo ${{ github.event.release.tag_name }} | cut -c2-) -r ${{ matrix.target }} -o out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
+        run: dotnet publish -p:PublishProfile=Default -p:Version=$(echo ${{ github.event.release.tag_name }} | cut -c2-) -r:${{ matrix.target }} -o:out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
 
       - name: Archive and Hash
         run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -25,7 +25,7 @@ jobs:
           dotnet-version: "8.0"
 
       - name: Build
-        run: dotnet publish -c Release --self-contained -p:DebugType=None -p:DebugSymbols=false -p:PublishReadyToRun=true -p:Version=0.0.0-test -r ${{ matrix.target }} -o out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
+        run: dotnet publish -p:PublishProfile=Default -p:Version=0.0.0-test -r:${{ matrix.target }} -o:out/${{ matrix.target }} -- ./src/yk-csr-cli/GenerateYKCSR.csproj
 
       - name: Archive and Hash
         run: |


### PR DESCRIPTION
Standardized the syntax for `dotnet publish` commands in both `release.yml` and `test-build.yml` workflows for consistency and readability. By aligning the command syntax, this change ensures that build instructions are uniformly applied across different environments, potentially reducing errors caused by syntax discrepancies. Specifically, this revision utilizes colon-prefixed options for the runtime (`-r:`) and output directory (`-o:`) arguments, aligning with best practices for CLI commands.

No related issues mentioned.