### PR TITLE
Optimize artifact handling in CI workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -29,11 +29,12 @@ jobs:
 
       - name: Archive and Hash
         run: |
-          zip -9 -r ./out/${{ matrix.target }}.zip ./out/${{ matrix.target }} -j
-          sha256sum ./out/${{ matrix.target }}.zip > ./out/${{ matrix.target }}.zip.sha256
+          mkdir artifacts
+          zip -9 -r ./artifacts/${{ matrix.target }}.zip ./out/${{ matrix.target }}/* -j
+          sha256sum ./artifacts/${{ matrix.target }}.zip > ./artifacts/${{ matrix.target }}.zip.sha256
 
       - name: Upload
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
           name: build-artifacts
-          path: ./out/*
+          path: ./artifacts/*


### PR DESCRIPTION
Introduced a dedicated 'artifacts' directory for storing the compressed and hashed build artifacts as part of the CI process. This improves organization and reduces the risk of accidental inclusion of unrelated files in the artifact upload step. Adjusted the archive and hash steps to utilize this new directory, and updated the upload step to target the new path, ensuring that only relevant build artifacts are preserved and shared.