### PR TITLE
Enhance artifact handling in CI workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -36,5 +36,18 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
         with:
-          name: build-artifacts
+          name: build-artifacts-${{ matrix.target }}
           path: ./artifacts/*
+
+  download:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts
+          pattern: build-artifacts-*
+          merge-multiple: true
+
+      - run: ls -R build-artifacts


### PR DESCRIPTION
Updated the CI workflow to uniquely name build artifacts based on the build matrix target, enabling more organized storage and retrieval. A new 'download' job merges these artifacts into a single directory for easier access. This approach allows for clearer distinction and manipulation of different build artifacts, especially useful in multi-target build scenarios.

Resolves issues with artifact clutter and simplifies artifact management in projects with complex CI pipelines.