### PR TITLE
Optimized artifact handling in CI workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -39,15 +39,12 @@ jobs:
           name: build-artifacts-${{ matrix.target }}
           path: ./artifacts/*
 
-  download:
-    needs: build
+  merge:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Merge Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/upload-artifact/merge@v4
         with:
-          path: build-artifacts
+          name: build-artifacts
           pattern: build-artifacts-*
-          merge-multiple: true
-
-      - run: ls -R build-artifacts


### PR DESCRIPTION
Replaced the artifact download step with a more efficient artifact merge strategy, utilizing `actions/upload-artifact/merge@v4`. This change streamlines CI operations by directly merging artifacts, eliminating redundant steps and manual file listings. The update focuses on enhancing the speed and simplicity of handling build artifacts across jobs, ensuring a smoother and more integrated CI process.

#NoIssueReference